### PR TITLE
Align file repository and endpoint with File model

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,3 +16,7 @@ GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 JWT_SECRET = os.getenv("JWT_SECRET")
 SESSION_SECRET_KEY = os.getenv("SESSION_SECRET_KEY")
+
+# Тестовый токен и пользователь для упрощённой авторизации
+TEST_AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
+TEST_USER_ID = os.getenv("TEST_USER_ID")

--- a/app/db/repository/file.py
+++ b/app/db/repository/file.py
@@ -1,6 +1,7 @@
 # file.py
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.models.file import File, Project
+from app.models.file import File
+from app.models.project import Project
 from typing import Optional
 from sqlalchemy.future import select
 
@@ -12,16 +13,16 @@ async def create_file(
     s3_key: str,
     bucket: str,
     content_type: str,
-    user_id: str,
-    project_id: str
+    project_id: str,
+    public_url: Optional[str] = None
 ) -> File:
     new_file = File(
         filename=filename,
         s3_key=s3_key,
         bucket=bucket,
         content_type=content_type,
-        user_id=user_id,
         project_id=project_id,
+        public_url=public_url,
     )
     db.add(new_file)
     await db.commit()
@@ -30,7 +31,7 @@ async def create_file(
 
 
 async def get_user_files_by_project_name(db: AsyncSession, user_id: str, project_name: Optional[str]):
-    stmt = select(File).join(Project).where(File.user_id == user_id, File.is_public == True)
+    stmt = select(File).join(Project).where(Project.user_id == user_id, File.is_public == True)
 
     if project_name:
         stmt = stmt.where(Project.name == project_name)

--- a/app/db/repository/user.py
+++ b/app/db/repository/user.py
@@ -1,4 +1,5 @@
 from sqlalchemy.future import select
+from typing import Optional
 from app.models.user import User
 
 async def get_or_create_user(db, user_info: dict) -> User:
@@ -14,3 +15,9 @@ async def get_or_create_user(db, user_info: dict) -> User:
     await db.commit()
     await db.refresh(user)
     return user
+
+
+async def get_user_by_id(db, user_id: int) -> Optional[User]:
+    stmt = select(User).where(User.id == user_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()


### PR DESCRIPTION
## Summary
- remove user_id handling from file repository and filter by project owner
- generate and store file public URL during upload
- allow passing a static token that maps to a specific user for testing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2cf6c200832db59671313b06bdb4